### PR TITLE
fix check to see if a push is a fast-forward

### DIFF
--- a/push.rb
+++ b/push.rb
@@ -77,7 +77,7 @@ dep 'ok to update.push', :ref, :remote do
       log_ok "The remote repo is empty."
     elsif !repo.repo_shell("git rev-parse #{remote_head}", &:ok?)
       confirm "The current HEAD on #{remote}, #{remote_head[0...7]}, isn't present locally. OK to push #{'(This is probably a bad idea)'.colorize('on red')}"
-    elsif shell("git merge-base #{ref} #{remote_head}", &:stdout) != remote_head
+    elsif shell("git merge-base #{ref} #{remote_head}", &:stdout).strip != remote_head
       confirm "Pushing #{ref} to #{remote} would not fast forward (#{remote} is on #{remote_head[0...7]}). That OK?"
     else
       true


### PR DESCRIPTION
This is a follow up to the fix to support git 2.11 sha's in 9854d50.

Shelling out to get the full sha1 includes a trailing \n, so we have to strip the result before comparing it